### PR TITLE
Use https rather than git port to clone Kibana submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kibana"]
 	path = kibana
-	url = git://github.com/elasticsearch/kibana.git
+	url = https://github.com/elasticsearch/kibana.git


### PR DESCRIPTION
Very minor change - this is more likely to work out of the box behind restrictive firewalls than SSH over the default port.
