### PR TITLE
Fix CAS bug auth with express version 3.4.8

### DIFF
--- a/lib/cas-auth.js
+++ b/lib/cas-auth.js
@@ -16,7 +16,7 @@ exports.configureCas = function(express, app, config) {
   config.cas_server_url = config.cas_server_url.replace(/\s+$/,'');
 
   app.get('/auth/cas/login', function (req, res) {
-    var service_url  = req.protocol + "://" + req.get('host') + req.url;
+    var service_url  = req.protocol + "://" + req.get('host') + req.originalUrl;
 
     var CAS = require('cas');
     var cas = new CAS({base_url: config.cas_server_url, service: service_url});


### PR DESCRIPTION
With express version 3.4.8, CAS authentication doesn't work.
Note: I don't test this patch with express version prior to 3.4.8
