### PR TITLE
Reverse proxy friendly

### DIFF
--- a/lib/es-proxy.js
+++ b/lib/es-proxy.js
@@ -23,7 +23,9 @@ function proxyRequest(request, response, host, port, user, password, getProxiedR
     var auth = 'Basic ' + new Buffer(user + ':' + password).toString('base64');
     filteredHeaders.authorization = auth;
   }
-
+  // be explicit. For ex: Nginx sets this to connection: close and ES craps out at that
+  // often with a ECONNRESET
+  filteredHeaders.connection = 'keep-alive';
   var options =  {
     path: getProxiedRequestPath(request),
     method: request.method,

--- a/lib/google-oauth.js
+++ b/lib/google-oauth.js
@@ -51,7 +51,7 @@ exports.configureOAuth = function(express, app, config) {
     passportIsSet = true;
 
     var protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == "https" ) ? "https" : "http";
-
+    var host  =  req.headers['x-forwarded-host'] || req.headers.host;
   //not doing anything with this:
   //it will try to serialize the users in the session.
     passport.serializeUser(function(user, done) {
@@ -61,7 +61,7 @@ exports.configureOAuth = function(express, app, config) {
       done(null, obj);
     });
 
-    var callbackUrl = protocol + "://" + req.headers.host + "/auth/google/callback";
+    var callbackUrl = protocol + "://" + host + "/auth/google/callback";
     passport.use(new GoogleStrategy({
       clientID: config.client_id, clientSecret: config.client_secret, callbackURL: callbackUrl
     }, function(accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
Check for X-Forwarded-Host so that kibana-authentication-proxy itself can be hosted behind a reverse proxy.

Also found a problem where the proxied request will result in a call to ES with http Connection header set to 'close'. ES will error out with a ECONNRESET at that sometimes.

Default behavior (w/o proxy) seems to be set 'Connection: keep-alive' - so setting that explicitly.
