### PR TITLE
Support elastic search on SSL. Currently, the config key es_using_ss...

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ require('./lib/cas-auth.js').configureCas(express, app, config);
 
 // Setup ES proxy
 require('./lib/es-proxy').configureESProxy(app, config.es_host, config.es_port,
-          config.es_username, config.es_password);
+          config.es_username, config.es_password, config.es_using_ssl);
 
 // Serve config.js for kibana3
 // We should use special config.js for the frontend and point the ES to __es/

--- a/lib/es-proxy.js
+++ b/lib/es-proxy.js
@@ -5,8 +5,9 @@
  * http://www.catonmat.net/http-proxy-in-nodejs/
  */
 var http = require('http');
+var https = require('https');
 
-function proxyRequest(request, response, host, port, user, password, getProxiedRequestPath, isUI) {
+function proxyRequest(request, response, host, port, user, password, useSSL, getProxiedRequestPath, isUI) {
   var filteredHeaders = {};
   Object.keys(request.headers).forEach(function(header) {
     if (header === 'host') {
@@ -35,7 +36,7 @@ function proxyRequest(request, response, host, port, user, password, getProxiedR
     options.auth = password ? user + ':' + password : user;
   }
 
-  var proxyReq = http.request(options);
+  var proxyReq = useSSL ?  https.request(options) : http.request(options);
 
   proxyReq.addListener('error', function(err){
     response.status(500).send('Unable to process your request, ' + err.code);
@@ -83,15 +84,15 @@ function proxyRequest(request, response, host, port, user, password, getProxiedR
   });
 }
 
-exports.configureESProxy = function(app, esHost, esPort, esUser, esPassword) {
+exports.configureESProxy = function(app, esHost, esPort, esUser, esPassword, useSSL) {
   app.use("/__es", function(request, response, next) {
-    proxyRequest(request, response, esHost, esPort, esUser, esPassword,
+    proxyRequest(request, response, esHost, esPort, esUser, esPassword, useSSL,
       function getProxiedRequestPath(request) {
         return request.url;
       });
   });
   app.use("/_plugin", function(request, response, next) {
-    proxyRequest(request, response, esHost, esPort, esUser, esPassword,
+    proxyRequest(request, response, esHost, esPort, esUser, esPassword, useSSL,
       function getProxiedRequestPath(request) {
         return request.originalUrl;
       }, true);


### PR DESCRIPTION
Fixes #39 by passing in the config key `es_using_ssl` and then appropriately creating a http/https proxy connection.
