### PR TITLE
escape asterisks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We currently support 3 auth methods: Google OAuth2, BasicAuth and CAS, you can u
 - ``enable_google_oauth``: *Enable or not?*
 - ``client_id``:  *The client ID of Google OAuth2, leave empty if you don't want to use it*
 - ``client_secret``: *The client secret of Google OAuth2*
-- ``allowed_emails``: *An emails list for the authorized users, should like `["a@b.com", "*@b.com", "*"]`*. All google users in the list will be allowed to access kibana.
+- ``allowed_emails``: *An emails list for the authorized users, should like `["a@b.com", "*\*@b.com", "**"]`*. All google users in the list will be allowed to access kibana.
 
 **Important**
 


### PR DESCRIPTION
Markdown rendering of these characters is incorrect, and led me to troubleshoot why "@mydomain.com" was not actually authorizing "myuser@mydomain.com"... of course I naturally arrived at attempting a wildcard, but only then did I notice this was actually clearly documented when viewing the readme with vim instead of off the github page.
